### PR TITLE
Monitor clients

### DIFF
--- a/console.rb
+++ b/console.rb
@@ -10,7 +10,13 @@ module Console
     'blue' => 34,
     'cyan' => 36,
     'magenta' => 35,
-    'light_green' => 92
+    'light_green' => 92,
+    'yellow' => 33,
+    'light_red' => 91,
+    'light_blue' => 94,
+    'light_cyan' => 96,
+    'light_magenta' => 95,
+    'light_gray' => 37
   }
 
   def self.color(color, text)

--- a/interrupt_client.rb
+++ b/interrupt_client.rb
@@ -17,7 +17,11 @@ class InterruptClient
   HANDSHAKE_WAIT                = 2 # number of seconds to wait for ack from server before resending
   TEXT_LINE                     = 10 # what line to print chat text on in terminal
 
-  COLORS = %w(green magenta cyan blue light_green)
+  COLORS = %w(
+    green magenta cyan blue
+    light_green light_red light_magenta yellow
+    light_blue light_gray red light_cyan
+  )
 
   def initialize(server_host, server_port)
     @server_host = server_host

--- a/interrupt_client.rb
+++ b/interrupt_client.rb
@@ -110,6 +110,9 @@ class InterruptClient
     return if msg.nil?
 
     case msg['type']
+    when 'ping'
+      send_msg(msg_ack())
+
     when 'chat'
       time = msg['time']
       return if time < @latest_chat
@@ -205,6 +208,8 @@ class InterruptClient
       (msg.has_key?('body') && msg.has_key?('names')) ? msg : nil
     when 'ack'
       msg
+    when 'ping'
+      msg
     else
       nil
     end
@@ -226,6 +231,10 @@ class InterruptClient
 
   def msg_quit
     {'type' => 'quit'}
+  end
+
+  def msg_ack
+    {'type' => 'ack'}
   end
   
   def terminal_config

--- a/interrupt_server.rb
+++ b/interrupt_server.rb
@@ -8,15 +8,16 @@ class InterruptServer
   MAX_MSG_LENGTH     = 1024 # max length of incoming message read
   PING_LENGTH        = 30 # how many seconds between pinging silent clients
   PING_TRIES         = 3 # how many times a client can be pinged without reply before being dropped
-  
-  def initialize(host, port, num_buckets=5)
+  NUM_BUCKETS        = 12
+
+  def initialize(host, port)
     @server = UDPSocket.new
     @server.bind(host, port)
 
     puts "running on host: #{host}"
 
     @clients = {}
-    @buckets_available = [*0..num_buckets-1]
+    @buckets_available = [*0..NUM_BUCKETS-1]
     # buckets: at most one client can be assigned a given bucket, though clients don't have to be assigned a bucket
     # the intended use on the client side is to use this to assign colors to users
 


### PR DESCRIPTION
This pull request:

- Adds a new thread to the server program that periodically sets a boolean instance variable to false. When this var is true, the main server thread resets it to false, and does some client monitoring activities (pinging clients in the client list, and removing clients who haven't been heard from in a while). The client program has been updated to reply with ack messages to pings from the server.

- Adds more colors (now 12 instead of 5), and makes it so that the client will cycle through the colors again when there are more clients than colors (instead of having all subsequent clients use the terminal default color).